### PR TITLE
Way to delete obsolete Kubernetes resources. Better naming.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,17 +4,18 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:
-    - id: trailing-whitespace
-    - id: end-of-file-fixer
-  - repo: https://github.com/timothycrosley/isort
-    rev: master
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.9
     hooks:
       - id: isort
+        additional_dependencies: [toml]
   - repo: https://github.com/psf/black
     rev: stable
     hooks:
-    - id: black
-      language_version: python3.6
+      - id: black
+        language_version: python3.6
   - repo: local
     hooks:
       - id: invoke-pre-commit

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Naming works as follows:
    rename them manually after creation.
  - Pipeline configs: `(build|release)-<component name>.yml`
 
+For deleting old Kubernetes resources, you can move your `.yaml` file under `kube/obsolete/` and it will be picked up AFTER the release of the `kube/*.yaml` files have been applied and the resources will be deleted.
+
 The `envs` have a few things to keep in mind.
 
 Firstly, every `envs/*` is expected to be run on one Kubernetes cluster
@@ -95,7 +97,8 @@ distribution.
 
 Secondly, you should store the sealed secrets generated with `kubeseal`
 to `envs/<env>/secrets/<num>-<name>.yaml`, e.g. `01-pipeline-agent.yaml`
-and they will be applied during release.
+and they will be applied during release. Similarly the files in
+`envs/<env>/secrets/obsolete/` will have their resources deleted.
 
 Thirdly, if you need to override any component's `kube/` configs, you
 can store an override to `envs/<env>/component/path/kube/<file>.yaml`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ pyyaml = "^5.1"
 
 [tool.poetry.dev-dependencies]
 
+[tool.isort]
+line_length = 88
+use_parentheses = true
+include_trailing_comma = true
+multi_line_output = 3
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Making `kube/obsolete/*.yaml` be run through `kubectl delete -f`. Also `envs/<env>/secrets/obsolete/*.yaml`.

Renamed kube `components` as `configs` to avoid confusion.

Also includes change to `isort` and related configuration as otherwise couldn't commit 😃