### PR TITLE
Fix issue with building images

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -29,11 +29,11 @@ validate_release_configs = task(devops.tasks.validate_release_configs)
         + ", ".join(ALL_COMPONENTS)
     },
 )
-def build_images(ctx, component=None):
-    if component is None:
+def build_images(ctx, component):
+    if not component:
         components = ALL_COMPONENTS
     else:
-        components = component.split(",")
+        components = [c.strip() for cs in component for c in cs.split(",")]
 
     if "DOCKER_HOST" not in environ:
         logger.warn(


### PR DESCRIPTION
`invoke build-images` raised `AttributeError: 'list' object has no attribute 'split'`, as the default value for an iterable parameter is an empty list. This is now fixed.

This new improved version can in addition also handle input like this:
`invoke build-images --component 'a,b, c' --component 'd, e' --component 'f'`