### PR TITLE
Bug fix: Only try to delete rel_path if it was actually created

### DIFF
--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -195,4 +195,5 @@ def release(
 
     if not keep_configs:
         logger.info(f"Removing temporary configurations from {rel_path}")
-        rmtree(rel_path)
+        if rel_path.exists():
+            rmtree(rel_path)


### PR DESCRIPTION
If you're running a release for an environment with no components the rel_path won't be created and hence deleting it will fail.