### PR TITLE
Bugfix: Use octal value for mode

### DIFF
--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -218,7 +218,7 @@ class Component:
     def _prepare_configs(self, dst: Path):
         dst = dst / self.path
         kube_dst = dst / "kube"
-        kube_dst.mkdir(mode=700, parents=True)
+        kube_dst.mkdir(mode=0o700, parents=True)
         logger.info(f"Writing configs to {dst}")
 
         dockerfile = self.path / "Dockerfile"


### PR DESCRIPTION
On macOS Mojave with Python 3.6.8 mode=700 ended up actually creating the directory as `d-w-r-xr--`. With mode=0o700, it ends up being created as intended, `drwx------`