### PR TITLE
Prevent running the pre-commit hook multiple times

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,4 +29,5 @@ repos:
         name: Invoke pre-commit task
         entry: local-precommit-hook
         language: script
+        pass_filenames: false
         files: \.(yaml)$  # Add more types when relevant


### PR DESCRIPTION
The local pre-commit hook is executed multiple times if there's a lot of changes to the templates and rendered files. See https://github.com/pre-commit/pre-commit/issues/83 for more details. This fixes that issue, so the pre-commit hook is called only once.

This fixes a race condition that happened when multiple instances of the update_from_templates got launched at the same time, each listing and trying to delete the same old files if you decided to rename a template.

Since the local pre-commit hook any way disregards the list of files modified, this will have the nice side effect of making it slightly faster in some cases, when it's running it only once instead of multiple times in parallel.