### PR TITLE
A bunch of small improvements

### DIFF
--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -9,7 +9,7 @@ import jinja2
 import yaml
 from devops.lib.log import logger
 from devops.lib.utils import label, merge_docs, run
-from devops.settings import KUBEVAL_SKIP_KINDS, TEMPLATE_HEADER
+from devops.settings import IMAGE_PREFIX, KUBEVAL_SKIP_KINDS, TEMPLATE_HEADER
 from invoke import Context
 
 try:
@@ -46,7 +46,7 @@ class Component:
         self.context = None
         self.image_pull_secrets = {}
         self.image = None
-        self.image_prefix = ""
+        self.image_prefix = IMAGE_PREFIX
         self.name = self._path_to_name(path)
         self.namespace = None
         self.orig_path = Path(path)
@@ -468,11 +468,15 @@ class Component:
 
         return self._resources
 
-    def _get_full_docker_name(self) -> str:
+    def get_docker_repository(self):
         prefix = self.image_prefix
         image = self.name
+        return f"{prefix}{image}"
+
+    def _get_full_docker_name(self) -> str:
+        docker_repository = self.get_docker_repository()
         tag = self.tag
-        return f"{prefix}{image}:{tag}"
+        return f"{docker_repository}:{tag}"
 
     @staticmethod
     def _get_resource_name(doc: dict) -> str:

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -7,7 +7,6 @@ from typing import List
 from devops.lib.component import Component
 from devops.lib.log import logger
 from devops.lib.utils import big_label, label, list_envs, load_env_settings, run
-from devops.settings import IMAGE_PREFIX
 from invoke import Context
 
 RELEASE_TMP = Path("temp")
@@ -24,7 +23,6 @@ def build_images(ctx, components, dry_run=False):
     big_label(logger.info, "Building images")
     for c in components:
         component = Component(c)
-        component.image_prefix = IMAGE_PREFIX
         component.build(ctx, dry_run)
 
 
@@ -182,7 +180,6 @@ def release(
             component.replicas = settings.REPLICAS[path]
             replica_counts.pop(path, None)
 
-        component.image_prefix = IMAGE_PREFIX
         component.namespace = settings.KUBE_NAMESPACE
         component.context = settings.KUBE_CONTEXT
         component.image_pull_secrets = settings.IMAGE_PULL_SECRETS

--- a/devops/tests/test_component.py
+++ b/devops/tests/test_component.py
@@ -1,7 +1,6 @@
 from io import StringIO
 
 import yaml
-
 from devops.lib.component import Component
 
 DEPLOYMENT = """
@@ -30,8 +29,19 @@ def get_deployment() -> dict:
     return yaml.load(StringIO(DEPLOYMENT), yaml.Loader)
 
 
+def test_get_docker_repository():
+    c = Component("service/test-service")
+    c.image_prefix = ""
+    assert c.get_docker_repository() == f"service-test-service"
+
+    c = Component("service/test-service")
+    c.image_prefix = "myproj-"
+    assert c.get_docker_repository() == f"myproj-service-test-service"
+
+
 def test_get_full_docker_name():
     c = Component("service/test-service")
+    c.image_prefix = ""
     assert c._get_full_docker_name() == "service-test-service:latest"
 
     c = Component("service/test-service")
@@ -43,6 +53,7 @@ def test_get_full_docker_name():
 def test_patch_containers():
     deploy = get_deployment()
     c = Component("service/test-service")
+    c.image_prefix = ""
     c.image = "test-image"
     c.tag = "v6.6.6"
     c._patch_containers(deploy)

--- a/tasks.py
+++ b/tasks.py
@@ -57,7 +57,13 @@ def build_images_context(components, dry_run):
     :param list components: The components to be built.
     :param bool dry_run: True if it's a dry run.
     """
-    yield
+
+    # Setup
+    try:
+        yield
+    finally:
+        # Teardown
+        pass
 
 
 @task(


### PR DESCRIPTION
- Add a `get_docker_repository` to make it possible to get the docker repository for a component. 
- Refactored the `_get_full_docker_name` to make use of the `get_docker_repository` function.
- Use the image prefix from settings by default, so that you don't need to separately assign it after instantiating a component.
- Added a `build_images_context` that is wrapping the build_images call. This will in practice be used in our case to temporarily copy in things, that due to the security restrictions of `docker build` can't be accessed during that command, and to remove them after the build has finished (or if it failed due to soem exception).
- The `release` invoke command now supports giving components the same way as to `build-images` and uses the `build-images` under the hood to make sure to also use the context manager.