### PR TITLE
Pass build-args to task and dev ops methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ poetry run invoke release <env> \
 # Build a specific component
 poetry run invoke build-images --component service/pipeline-agent
 
+# Pass build args
+poetry run invoke build-images --component service/pipeline-agent --docker-args=foo=bar --docker-args=boo=far ...
+
 # Clean up the Azure Container Registry, name is from <name>.azurecr.io
 poetry run invoke cleanup-registry <name>
 ```

--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -94,10 +94,12 @@ class Component:
 
         if isinstance(docker_args, list):
             # Insert --build-arg before each item in docker_args.
-            docker_args = [["--build-arg", docker_arg] if docker_arg else "" for docker_arg in docker_args]
+            docker_args = [["--build-arg", docker_arg] for docker_arg in
+                           docker_args]
             # Flatten list
             # build_args_pair is ["--build-arg", "foo=bar"]
-            docker_args = [arg for build_args_pair in docker_args for arg in build_args_pair]
+            docker_args = [arg for build_args_pair in docker_args for arg in
+                           build_args_pair]
         else:
             docker_args = []
 

--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -84,7 +84,7 @@ class Component:
             if result.returncode > 0:
                 raise ValidationError(f"Validation failed for {path}")
 
-    def build(self, ctx: Context, dry_run=False):
+    def build(self, ctx: Context, dry_run=False, docker_args=None):
         label(logger.info, f"Building {self.path}")
         dockerfile = self.path / "Dockerfile"
 
@@ -92,12 +92,21 @@ class Component:
             logger.info(f"No Dockerfile for {self.name} component")
             return
 
+        if isinstance(docker_args, list):
+            # Insert --build-arg before each item in docker_args.
+            docker_args = [["--build-arg", x] if x else "" for x in docker_args]
+            # Flatten list
+            docker_args = [y for x in docker_args for y in x]
+        else:
+            docker_args = []
+
         if dry_run:
             logger.info(f"[DRY RUN] Building {self.name} Docker image")
         else:
             logger.info(f"Building {self.name} Docker image")
             tag = self._get_full_docker_name()
-            run(["docker", "build", self.path, "-t", tag], stream=True)
+            run(["docker", "build", *docker_args, self.path, "-t", tag],
+                stream=True)
 
     def patch_from_env(self, env):
         env_path = Path("envs") / env / "overrides" / self.path.as_posix()

--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -94,9 +94,10 @@ class Component:
 
         if isinstance(docker_args, list):
             # Insert --build-arg before each item in docker_args.
-            docker_args = [["--build-arg", x] if x else "" for x in docker_args]
+            docker_args = [["--build-arg", docker_arg] if docker_arg else "" for docker_arg in docker_args]
             # Flatten list
-            docker_args = [y for x in docker_args for y in x]
+            # build_args_pair is ["--build-arg", "foo=bar"]
+            docker_args = [arg for build_args_pair in docker_args for arg in build_args_pair]
         else:
             docker_args = []
 

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -20,7 +20,8 @@ def generate_release_id() -> str:
 
 
 def build_images(ctx, components, dry_run=False, docker_args=None):
-    big_label(logger.info, f"Building images with args {docker_args}")
+    big_label(logger.info,
+              f"Building images{f' with args: {docker_args}' if docker_args else ''}")
     for c in components:
         component = Component(c)
         component.build(ctx, dry_run, docker_args)

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -19,11 +19,14 @@ def generate_release_id() -> str:
     return "".join(random.choice(chars) for _ in range(length))  # nosec
 
 
-def build_images(ctx, components, dry_run=False):
-    big_label(logger.info, "Building images")
+def build_images(ctx, components, dry_run=False, docker_args=None):
+    if docker_args is None:
+        docker_args = []
+
+    big_label(logger.info, f"Building images with args {docker_args}")
     for c in components:
         component = Component(c)
-        component.build(ctx, dry_run)
+        component.build(ctx, dry_run, docker_args)
 
 
 def update_from_templates(ctx):

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -20,9 +20,6 @@ def generate_release_id() -> str:
 
 
 def build_images(ctx, components, dry_run=False, docker_args=None):
-    if docker_args is None:
-        docker_args = []
-
     big_label(logger.info, f"Building images with args {docker_args}")
     for c in components:
         component = Component(c)

--- a/tasks.py
+++ b/tasks.py
@@ -30,10 +30,8 @@ validate_release_configs = task(devops.tasks.validate_release_configs)
                      + ", ".join(ALL_COMPONENTS),
         "dry_run": "Do not perform any changes, just generate configs and log what would be done",
         "docker_args": (
-                "Arguments to build docker images. "
-                + "Passed as --build-arg to docker build. If you want to"
-                + " pass several build argument, pass each of them as a "
-                + "separate argument"
+                "Arguments to build docker imaages --docker-args foo=bar. "
+                + "Repeat for multiple build arguments."
         ),
     },
 )

--- a/tasks.py
+++ b/tasks.py
@@ -24,14 +24,20 @@ validate_release_configs = task(devops.tasks.validate_release_configs)
 
 
 @task(
-    iterable=["component"],
+    iterable=["component", "docker_args"],
     help={
         "component": "The components to build - if none given defaults to: "
         + ", ".join(ALL_COMPONENTS),
         "dry_run": "Do not perform any changes, just generate configs and log what would be done",
+        "docker_args": (
+                "Arguments to build docker images. "
+                + "Passed as --build-arg to docker build. If you want to"
+                + " build several components, pass them as "
+                + "separate arguments"
+        ),
     },
 )
-def build_images(ctx, component, dry_run):
+def build_images(ctx, component, dry_run, docker_args=None):
     if not component:
         components = ALL_COMPONENTS
     else:
@@ -42,8 +48,11 @@ def build_images(ctx, component, dry_run):
             'DOCKER_HOST not set, if you get an error you might be missing something like "minikube start"'
         )
 
+    if not docker_args:
+        docker_args = []
+
     with build_images_context(components, dry_run):
-        devops.tasks.build_images(ctx, components, dry_run)
+        devops.tasks.build_images(ctx, components, dry_run, docker_args)
 
 
 @contextmanager

--- a/tasks.py
+++ b/tasks.py
@@ -27,13 +27,13 @@ validate_release_configs = task(devops.tasks.validate_release_configs)
     iterable=["component", "docker_args"],
     help={
         "component": "The components to build - if none given defaults to: "
-        + ", ".join(ALL_COMPONENTS),
+                     + ", ".join(ALL_COMPONENTS),
         "dry_run": "Do not perform any changes, just generate configs and log what would be done",
         "docker_args": (
                 "Arguments to build docker images. "
                 + "Passed as --build-arg to docker build. If you want to"
-                + " build several components, pass them as "
-                + "separate arguments"
+                + " pass several build argument, pass each of them as a "
+                + "separate argument"
         ),
     },
 )
@@ -47,9 +47,6 @@ def build_images(ctx, component, dry_run, docker_args=None):
         logger.warn(
             'DOCKER_HOST not set, if you get an error you might be missing something like "minikube start"'
         )
-
-    if not docker_args:
-        docker_args = []
 
     with build_images_context(components, dry_run):
         devops.tasks.build_images(ctx, components, dry_run, docker_args)


### PR DESCRIPTION
Pass `docker-args` to build methods.

From invoke tasks it should be used as follows:

```
run invoke docker.build-images --component services/router --docker-args=foo=bar --docker-args=boo=far ...
```