### PR TITLE
Make dry_run optional for build_images task

### DIFF
--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -92,24 +92,18 @@ class Component:
             logger.info(f"No Dockerfile for {self.name} component")
             return
 
-        if isinstance(docker_args, list):
-            # Insert --build-arg before each item in docker_args.
-            docker_args = [["--build-arg", docker_arg] for docker_arg in
-                           docker_args]
-            # Flatten list
-            # build_args_pair is ["--build-arg", "foo=bar"]
-            docker_args = [arg for build_args_pair in docker_args for arg in
-                           build_args_pair]
-        else:
-            docker_args = []
+        build_args = []
+        if docker_args:
+            # Insert --build-arg before each item from docker_args.
+            for docker_arg in docker_args:
+                build_args.extend(["--build-arg", docker_arg])
 
         if dry_run:
             logger.info(f"[DRY RUN] Building {self.name} Docker image")
         else:
             logger.info(f"Building {self.name} Docker image")
             tag = self._get_full_docker_name()
-            run(["docker", "build", *docker_args, self.path, "-t", tag],
-                stream=True)
+            run(["docker", "build", *build_args, self.path, "-t", tag], stream=True)
 
     def patch_from_env(self, env):
         env_path = Path("envs") / env / "overrides" / self.path.as_posix()

--- a/tasks.py
+++ b/tasks.py
@@ -30,7 +30,7 @@ validate_release_configs = task(devops.tasks.validate_release_configs)
         + ", ".join(ALL_COMPONENTS),
         "dry_run": "Do not perform any changes, just generate configs and log what would be done",
         "docker_args": (
-            "Arguments to build docker imaages --docker-args foo=bar. "
+            "Arguments to build docker images --docker-args foo=bar. "
             + "Repeat for multiple build arguments."
         ),
     },

--- a/tasks.py
+++ b/tasks.py
@@ -29,10 +29,8 @@ validate_release_configs = task(devops.tasks.validate_release_configs)
         "component": "The components to build - if none given defaults to: "
         + ", ".join(ALL_COMPONENTS),
         "dry_run": "Do not perform any changes, just generate configs and log what would be done",
-        "docker_args": (
-            "Arguments to build docker images --docker-args foo=bar. "
-            + "Repeat for multiple build arguments."
-        ),
+        "docker_args": "Arguments to build docker images --docker-args foo=bar. "
+        + "Repeat for multiple build arguments.",
     },
 )
 def build_images(ctx, component, dry_run=False, docker_args=None):

--- a/tasks.py
+++ b/tasks.py
@@ -27,15 +27,15 @@ validate_release_configs = task(devops.tasks.validate_release_configs)
     iterable=["component", "docker_args"],
     help={
         "component": "The components to build - if none given defaults to: "
-                     + ", ".join(ALL_COMPONENTS),
+        + ", ".join(ALL_COMPONENTS),
         "dry_run": "Do not perform any changes, just generate configs and log what would be done",
         "docker_args": (
-                "Arguments to build docker imaages --docker-args foo=bar. "
-                + "Repeat for multiple build arguments."
+            "Arguments to build docker imaages --docker-args foo=bar. "
+            + "Repeat for multiple build arguments."
         ),
     },
 )
-def build_images(ctx, component, dry_run, docker_args=None):
+def build_images(ctx, component, dry_run=False, docker_args=None):
     if not component:
         components = ALL_COMPONENTS
     else:


### PR DESCRIPTION
By accident the dry_run parameter had no default value when it was added by me. It got added in commit c7382b6cc2851ad3c68807c773fabfc95e7aeb39.

P.S. Apparently the last merged changes were not run through black, as the formatting of the help changes introduced in between got reformatted.