### PR TITLE
Changes to settings trigger pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
         entry: local-precommit-hook
         language: script
         pass_filenames: false
-        files: \.(yaml)$  # Add more types when relevant
+        files: (\.(yaml)$|envs\/.*\/settings\.py$)  # Add more types when relevant


### PR DESCRIPTION
Changes to envs/<env>/settings.py also needs to trigger the pre-commit hook that renders yaml files. If not, then it's possible to by accident commit a change to the variables that is not reflected in the rendered versions.