### PR TITLE
Unify order of env/context and overrides in paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ under `envs/<env>/secrets.pem` and you most likely want to commit that to the
 repository to make it easy to add new secrets.
 
 If you need to override any of the files from `kube/*.yaml` for some cluster,
-you can do that by adding an identically named file in `kube/overrides/<kube_context>/*.yaml`.
+you can do that by adding an identically named file in `kube/<kube_context>/overrides/*.yaml`.
 The `<kube_context>` should match the `KUBE_CONTEXT` value defined in `envs/<env>/settings.py`.
 This approach can for example be used to customize the `KURED_SLACK_NAME` for each cluster by making
 a cluster/context specific override of the `02-kured.yaml` file.

--- a/tasks.py
+++ b/tasks.py
@@ -131,7 +131,7 @@ def init_kubernetes(ctx, env):
     def _get_kube_files(kube_context):
         kube_files = {f.name: f for f in Path("kube").glob("*.yaml")}
 
-        overrides = (Path("kube") / "overrides" / kube_context).glob("*.yaml")
+        overrides = (Path("kube") / kube_context / "overrides").glob("*.yaml")
         for f in overrides:
             kube_files[f.name] = f
 


### PR DESCRIPTION
The overrides for components are in paths of the form
`envs/<env>/overrides/...*.yaml`
and the kubernetes overrides were added on the form
`kube/overrides/<kube_context>/*.yaml`.

This fixes it to be consistent, by switching to
`kube/<kube_context>/overrides/*.yaml`, so the `overrides` folder comes after the context/env also here.