### PR TITLE
Update sealed secrets controller to 0.9.6 from 0.9.0

### DIFF
--- a/kube/01-sealed-secrets-controller.yaml
+++ b/kube/01-sealed-secrets-controller.yaml
@@ -1,17 +1,19 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: v1
+kind: Service
 metadata:
-  name: sealedsecrets.bitnami.com
+  annotations: {}
+  labels:
+    name: sealed-secrets-controller
+  name: sealed-secrets-controller
+  namespace: kube-system
 spec:
-  group: bitnami.com
-  names:
-    kind: SealedSecret
-    listKind: SealedSecretList
-    plural: sealedsecrets
-    singular: sealedsecret
-  scope: Namespaced
-  version: v1alpha1
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    name: sealed-secrets-controller
+  type: ClusterIP
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -29,26 +31,6 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:authenticated
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
-metadata:
-  annotations: {}
-  labels:
-    name: sealed-secrets-service-proxier
-  name: sealed-secrets-service-proxier
-  namespace: kube-system
-rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - 'http:sealed-secrets-controller:'
-  - sealed-secrets-controller
-  resources:
-  - services/proxy
-  verbs:
-  - create
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
@@ -126,7 +108,7 @@ metadata:
   name: sealed-secrets-controller
   namespace: kube-system
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations: {}
@@ -137,6 +119,7 @@ metadata:
 spec:
   minReadySeconds: 30
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       name: sealed-secrets-controller
@@ -156,7 +139,7 @@ spec:
         command:
         - controller
         env: []
-        image: quay.io/bitnami/sealed-secrets-controller:v0.9.0
+        image: quay.io/bitnami/sealed-secrets-controller:v0.9.6
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -187,21 +170,39 @@ spec:
       - emptyDir: {}
         name: tmp
 ---
-apiVersion: v1
-kind: Service
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: sealedsecrets.bitnami.com
+spec:
+  group: bitnami.com
+  names:
+    kind: SealedSecret
+    listKind: SealedSecretList
+    plural: sealedsecrets
+    singular: sealedsecret
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
 metadata:
   annotations: {}
   labels:
-    name: sealed-secrets-controller
-  name: sealed-secrets-controller
+    name: sealed-secrets-service-proxier
+  name: sealed-secrets-service-proxier
   namespace: kube-system
-spec:
-  ports:
-  - port: 8080
-    targetPort: 8080
-  selector:
-    name: sealed-secrets-controller
-  type: ClusterIP
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - 'http:sealed-secrets-controller:'
+  - sealed-secrets-controller
+  resources:
+  - services/proxy
+  verbs:
+  - create
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding


### PR DESCRIPTION
If you try to run `poetry run invoke-kubernetes` on a too new Kubernetes cluster, you will get the following error message:

error: unable to recognize "kube/01-sealed-secrets-controller.yaml": no matches for kind "Deployment" in version "apps/v1beta2"

According to https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ the v1.16 release of kubernetes stopped serving the deprecated API apps/v1beta for Deployment.

According to the release notes for sealed secrets, the issue was resolved in version 0.9.1:https://github.com/bitnami-labs/sealed-secrets/blob/master/RELEASE-NOTES.md#v091

Considered it best to update all the way to the latest version, thus updating to 0.9.6.

The updated version was fetched from http://github.com/bitnami-labs/sealed-secrets/releases/download/v0.9.6/controller.yaml

Azure does not yet offer kubernetes 1.16, but the latest version of minikube is already running kubernetes 1.17.