### PR TITLE
Minor improvements

### DIFF
--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -90,8 +90,15 @@ def ensure_namespace(namespace):
 def release_env(ctx: Context, env, dry_run=False):
     env_path = Path("envs") / env
 
-    secrets = (env_path / "secrets").glob("*.yaml")
-    for secret in sorted(secrets):
+    secrets = sorted(
+        [
+            secret_file
+            for secret_file in (env_path / "secrets").glob("*.yaml")
+            if not secret_file.name.endswith(UNSEALED_SECRETS_EXTENSION)
+        ]
+    )
+
+    for secret in secrets:
         # Sealed Secrets can't be validated like this
         # ctx.run(f"kubeval {secret}")
         if dry_run:

--- a/devops/tests/test_tasks.py
+++ b/devops/tests/test_tasks.py
@@ -1,6 +1,5 @@
 import subprocess
 
-import devops.lib.utils
 from devops.settings import UNSEALED_SECRETS_EXTENSION
 from devops.tasks import (
     base64_decode_secrets,

--- a/tasks.py
+++ b/tasks.py
@@ -41,7 +41,7 @@ def build_images(ctx, component, dry_run=False, docker_args=None):
 
     if "DOCKER_HOST" not in environ:
         logger.warn(
-            'DOCKER_HOST not set, if you get an error you might be missing something like "minikube start"'
+            'DOCKER_HOST not set. You might want to run "minikube start" or run "minikube docker-env" and follow the instructions.'
         )
 
     with build_images_context(components, dry_run):


### PR DESCRIPTION
- Improve message if DOCKER_HOST is not set.
- Remove unused import
- Prevent release command from trying to apply unsealed-secrets.yaml files. Could easily happen in local minikube env that you have an unsealed copy of the files for easy editing and still want to be able to carry out a local "release".