### PR TITLE
Fix list_envs function to ignore folders starting with "."

### DIFF
--- a/devops/lib/utils.py
+++ b/devops/lib/utils.py
@@ -36,11 +36,13 @@ def load_env_settings(env: str) -> Settings:
 
 
 def list_envs() -> List[str]:
-    envs = []
-
-    for path in Path("envs").iterdir():  # type: Path
-        if path.is_dir() and not path.name.startswith("__"):
-            envs.append(path.name)
+    envs = [
+        path.name
+        for path in Path("envs").iterdir()
+        if path.is_dir()
+        and not path.name.startswith("__")
+        and not path.name.startswith(".")
+    ]
 
     return envs
 

--- a/devops/tests/test_utils.py
+++ b/devops/tests/test_utils.py
@@ -10,8 +10,9 @@ import yaml
 
 from devops.lib.utils import list_envs, load_env_settings, run, merge_docs
 
+ENVS_PATH = Path("envs")
 TEST_ENV = "unit_test_env_6zxuj"
-TEST_ENV_PATH = Path("envs") / TEST_ENV
+TEST_ENV_PATH = ENVS_PATH / TEST_ENV
 TEST_ENV_SETTINGS = TEST_ENV_PATH / "settings.py"
 
 TEST_SETTINGS = """
@@ -330,3 +331,16 @@ def test_readme_kube_merge():
         print(f"Doc {i + 1} actual  : {merged_json}")
 
         assert merged_json == expected_json
+
+
+@pytest.mark.parametrize("folder", ["__foo__", ".bar"])
+def test_list_envs(folder):
+    path = ENVS_PATH / folder
+    path.mkdir()
+    try:
+        envs = list_envs()
+
+        assert folder not in envs
+        assert "minikube" in envs
+    finally:
+        path.rmdir()


### PR DESCRIPTION
- Ignore directories starting with a dot
- Add tests for list_envs