### PR TITLE
Add seed-isort-config to pre-commit hooks

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-known_third_party = invoke,jinja2,pytest,ruamel,yaml

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = invoke,jinja2,pytest,ruamel,yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,10 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.4
+    hooks:
+      - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.9
+    rev: v4.3.21
     hooks:
       - id: isort
         additional_dependencies: [toml]

--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -140,7 +140,9 @@ class Component:
 
             with old_file.open(mode="r", encoding="utf-8") as f:
                 content = f.read()
-            if content.startswith(TEMPLATE_HEADER.format(file=template_path.as_posix())):
+            if content.startswith(
+                TEMPLATE_HEADER.format(file=template_path.as_posix())
+            ):
                 old_file.unlink()
                 logger.debug(f"Deleted rendered file {old_file}")
             else:

--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -7,10 +7,11 @@ from typing import List, Optional
 
 import jinja2
 import yaml
+from invoke import Context
+
 from devops.lib.log import logger
 from devops.lib.utils import label, merge_docs, run
 from devops.settings import IMAGE_PREFIX, KUBEVAL_SKIP_KINDS, TEMPLATE_HEADER
-from invoke import Context
 
 try:
     from yaml import CBaseLoader as BaseLoader, CLoader as Loader, CDumper as Dumper

--- a/devops/lib/utils.py
+++ b/devops/lib/utils.py
@@ -2,12 +2,9 @@ import importlib
 import subprocess  # nosec
 import types
 from copy import deepcopy
-from io import StringIO
 from pathlib import Path
 from time import time
 from typing import Callable, List, Optional, Union
-
-import yaml
 
 from devops.lib.log import logger
 

--- a/devops/lib/utils.py
+++ b/devops/lib/utils.py
@@ -8,6 +8,7 @@ from time import time
 from typing import Callable, List, Optional, Union
 
 import yaml
+
 from devops.lib.log import logger
 
 

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from shutil import rmtree
 from typing import List
 
+from invoke import Context
+from ruamel.yaml import YAML
+from ruamel.yaml.compat import StringIO
+from ruamel.yaml.scalarstring import LiteralScalarString, PlainScalarString
+
 from devops.lib.component import Component
 from devops.lib.log import logger
 from devops.lib.utils import (
@@ -17,10 +22,6 @@ from devops.lib.utils import (
     secrets_pem_path,
 )
 from devops.settings import UNSEALED_SECRETS_EXTENSION
-from invoke import Context
-from ruamel.yaml import YAML
-from ruamel.yaml.compat import StringIO
-from ruamel.yaml.scalarstring import LiteralScalarString, PlainScalarString
 
 RELEASE_TMP = Path("temp")
 

--- a/devops/tests/test_component.py
+++ b/devops/tests/test_component.py
@@ -1,6 +1,7 @@
 from io import StringIO
 
 import yaml
+
 from devops.lib.component import Component
 
 DEPLOYMENT = """

--- a/devops/tests/test_tasks.py
+++ b/devops/tests/test_tasks.py
@@ -1,5 +1,7 @@
 import subprocess
 
+from ruamel.yaml import YAML
+
 from devops.settings import UNSEALED_SECRETS_EXTENSION
 from devops.tasks import (
     base64_decode_secrets,
@@ -15,7 +17,6 @@ from devops.tests.test_utils import (
     TEST_SETTINGS,
     clean_test_settings,
 )
-from ruamel.yaml import YAML
 
 TEST_ENV_SECRETS_PATH = TEST_ENV_PATH / "secrets"
 TEST_ENV_SEALED_SECRETS_PATH = TEST_ENV_SECRETS_PATH / "01-test-secrets.yaml"

--- a/devops/tests/test_utils.py
+++ b/devops/tests/test_utils.py
@@ -7,6 +7,7 @@ from shutil import rmtree
 
 import pytest
 import yaml
+
 from devops.lib.utils import list_envs, load_env_settings, merge_docs, run
 
 ENVS_PATH = Path("envs")

--- a/devops/tests/test_utils.py
+++ b/devops/tests/test_utils.py
@@ -7,8 +7,7 @@ from shutil import rmtree
 
 import pytest
 import yaml
-
-from devops.lib.utils import list_envs, load_env_settings, run, merge_docs
+from devops.lib.utils import list_envs, load_env_settings, merge_docs, run
 
 ENVS_PATH = Path("envs")
 TEST_ENV = "unit_test_env_6zxuj"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ line_length = 88
 use_parentheses = true
 include_trailing_comma = true
 multi_line_output = 3
+known_third_party = ["invoke", "jinja2", "pytest", "ruamel", "yaml"]
 
 # Not actually supported yet, future-proofing
 [tool.bandit]

--- a/tasks.py
+++ b/tasks.py
@@ -6,11 +6,12 @@ from pathlib import Path
 from subprocess import CalledProcessError  # nosec
 from time import sleep
 
+from invoke import Context, task
+
 import devops.settings
 import devops.tasks
 from devops.lib.log import logger
 from devops.lib.utils import big_label, label, list_envs, load_env_settings, run
-from invoke import Context, task
 
 ALL_COMPONENTS = ["service/pipeline-agent"]
 


### PR DESCRIPTION
When isort is run by pre-commit, it's not run within the virtualenv of the project and hence it doesn't properly detect the third party imports, causing them to be incorrectly sorted. https://github.com/pre-commit/mirrors-isort also mentions that isort is not always good at classifying imports and links to https://github.com/asottile/seed-isort-config. Anthony Sottile (asottile) who owns the repo it's hosted in is one of the public members of the pre-commit organization.

This PR:
- Adds seed-isort-config to the pre-commit hooks
- Updates isort used by pre-commit to latest version
- Updates pre-commit itself to the latest version
- Changes from running `pre-commit run --all-files`; one minor thing fixed by black and a lot of imports that got sorted properly
- Remove unused imports