### PR TITLE
Ignore merges when running kubeval checks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -263,8 +263,10 @@ def kubeval(ctx):
     label(logger.info, "Checking Kubernetes configs")
 
     def _should_ignore(path):
-        s = str(path)
-        if s.startswith("temp"):
+        parts = path.parts
+        if parts[0] == "temp":
+            return True
+        elif parts[0] == "envs" and parts[2] == "merges":
             return True
 
         return False


### PR DESCRIPTION
The yaml files placed under `envs/{env}/merges/` are in nature partial kubernetes files. They are often missing the `kind` and other fields deemed mandatory by kubeval, so they can't be properly checked using kubeval.

This PR thus ignores those merge templates from being checked by the `invoke kubeval` command and the pre-commit hooks. The only proper way to validate those would be to assemble the full version of the template from them and validate that result instead.

It also makes the check for ignoring the `temp` folder a bit more robust.