### PR TITLE
Run kubeval in strict mode

### DIFF
--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -81,7 +81,7 @@ class Component:
 
         for file in self.kube_configs:
             path = self.kube_configs[file]
-            result = run(["kubeval", "--skip-kinds", skip_kinds, path])
+            result = run(["kubeval", "--strict", "--skip-kinds", skip_kinds, path])
             if result.returncode > 0:
                 raise ValidationError(f"Validation failed for {path}")
 

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -258,7 +258,7 @@ def kubeval(keep_configs=False):
 
     skip_kinds = ",".join(KUBEVAL_SKIP_KINDS)
 
-    run(["kubeval", "--skip-kinds", skip_kinds] + kube_yamls)
+    run(["kubeval", "--strict", "--skip-kinds", skip_kinds] + kube_yamls)
 
     if not keep_configs and merge_tmp.exists():
         logger.info(f"Removing temporary kube merges from {merge_tmp}")


### PR DESCRIPTION
In strict mode kubeval will `Disallow additional properties not in schema`.

This change was inspired from the discussion in [PR #30](https://github.com/Lieturd/project-template/pull/30).

With the strict flag it will for example from this yaml:
```
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: test-cronjob
spec:
  schedule: '* * * * *'
  jobTemplate:
    spec:
      replicas: 1
      template:
        metadata:
          labels:
            app: test-cronjob
        spec:
          containers:
            - name: test-cronjob
              imagePullPolicy: IfNotPresent
              image: imagined.registry.tld/myproj-service-test-cronjob:latest
```
produce this error/warning (it's labeled as a warning, but exits with code 1):
```
WARN - service/pipeline-agent/kube/cronjob.yaml contains an invalid CronJob - replicas: Additional property replicas is not allowed
```