### PR TITLE
Cross-platform syntax for running local pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: invoke-pre-commit
         name: Invoke pre-commit task
-        entry: local-precommit-hook
-        language: script
+        entry: poetry run invoke pre-commit
+        language: system
         pass_filenames: false
         files: (\.(yaml)$|envs\/.*\/settings\.py$)  # Add more types when relevant


### PR DESCRIPTION
`script` only works on *nix, `system` runs any command and can be used to trigger cross-platform utilities like poetry & invoke

Couldn't find better docs than this https://github.com/pre-commit/pre-commit/blob/master/pre_commit/languages/system.py