### PR TITLE
Fix deletion of rendered templates for removed components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .idea
 __pycache__
 *.pyc

--- a/devops/lib/component.py
+++ b/devops/lib/component.py
@@ -157,6 +157,8 @@ class Component:
 
         if not self.kube_templates[kind]:
             return rendered_files
+        if self.orig_path.as_posix() not in settings.COMPONENTS:
+            return rendered_files
 
         logger.info(f"Creating {kind} files for {self.name} for env {env}")
 

--- a/devops/lib/utils.py
+++ b/devops/lib/utils.py
@@ -1,5 +1,6 @@
 import importlib
 import subprocess  # nosec
+import sys
 import types
 from copy import deepcopy
 from pathlib import Path
@@ -25,6 +26,8 @@ class Settings:
 
 def load_env_settings(env: str) -> Settings:
     module = f"envs.{env}.settings"
+    if module in sys.modules:
+        del sys.modules[module]
     logger.info(f"Loading settings from {module}")
     settings = importlib.import_module(module)
 

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -45,7 +45,7 @@ def build_images(ctx, components, dry_run=False, docker_args=None):
         component.build(ctx, dry_run, docker_args)
 
 
-def update_from_templates(ctx):
+def update_from_templates():
     envs = list_envs()
 
     rendered_files = []

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -51,9 +51,18 @@ def update_from_templates():
     rendered_files = []
     for env in envs:
         settings = load_env_settings(env)
-        components = settings.COMPONENTS
+        enabled_components = set(settings.COMPONENTS)
 
-        for path in components:
+        components_in_filesystem = {
+            p.parent.relative_to("envs", env, "merges").as_posix()
+            for p in Path("envs", env, "merges").glob("**/kube")
+        }
+        components_in_filesystem |= {
+            p.parent.relative_to("envs", env, "overrides").as_posix()
+            for p in Path("envs", env, "overrides").glob("**/kube")
+        }
+
+        for path in enabled_components | components_in_filesystem:
             component = Component(path)
             rendered_files.extend(component.render_templates(env, settings))
 

--- a/devops/tests/conftest.py
+++ b/devops/tests/conftest.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from shutil import rmtree
+
+import pytest
+
+ENVS_PATH = Path("envs")
+TEST_ENV = "unit_test_env_6zxuj"
+TEST_ENV_PATH = ENVS_PATH / TEST_ENV
+
+TEST_COMPONENT_PATH = Path("service/TEST_COMPONENT_LOL")
+
+
+@pytest.fixture()
+def clean_test_settings():
+    delete_test_settings()
+    yield None
+    delete_test_settings()
+
+
+@pytest.fixture()
+def clean_test_component():
+    delete_test_component()
+    yield None
+    delete_test_component()
+
+
+def delete_test_settings():
+    if TEST_ENV_PATH.exists():
+        rmtree(TEST_ENV_PATH)
+
+
+def delete_test_component():
+    if TEST_COMPONENT_PATH.exists():
+        rmtree(TEST_COMPONENT_PATH)

--- a/devops/tests/conftest.py
+++ b/devops/tests/conftest.py
@@ -6,8 +6,15 @@ import pytest
 ENVS_PATH = Path("envs")
 TEST_ENV = "unit_test_env_6zxuj"
 TEST_ENV_PATH = ENVS_PATH / TEST_ENV
+TEST_ENV_SETTINGS = TEST_ENV_PATH / "settings.py"
 
 TEST_COMPONENT_PATH = Path("service/TEST_COMPONENT_LOL")
+
+TEST_SETTINGS = """
+COMPONENTS = ["service/TEST_COMPONENT_LOL"]
+KUBE_CONTEXT = "TEST_CONTEXT_LOL"
+KUBE_NAMESPACE = "TEST_NAMESPACE_LOL"
+"""
 
 
 @pytest.fixture()

--- a/devops/tests/test_tasks.py
+++ b/devops/tests/test_tasks.py
@@ -13,16 +13,46 @@ from devops.tasks import (
     unseal_secrets,
     update_from_templates,
 )
-from devops.tests.conftest import TEST_ENV, TEST_ENV_PATH
-from devops.tests.test_utils import (
-    TEST_COMPONENT_OVERRIDE_TEMPLATE,
-    TEST_COMPONENT_OVERRIDE_TEMPLATE_PATH,
-    TEST_COMPONENT_RENDERED_OVERRIDE,
-    TEST_COMPONENT_RENDERED_OVERRIDE_PATH,
+from devops.tests.conftest import (
+    TEST_COMPONENT_PATH,
+    TEST_ENV,
+    TEST_ENV_PATH,
     TEST_ENV_SETTINGS,
     TEST_SETTINGS,
-    TEST_SETTINGS_WITH_VARIABLES,
 )
+
+TEST_SETTINGS_WITH_VARIABLES = (
+    TEST_SETTINGS
+    + """
+TEMPLATE_VARIABLES = {"ENV": "development"}
+"""
+)
+
+TEST_COMPONENT_OVERRIDE_TEMPLATE_PATH = (
+    TEST_COMPONENT_PATH / "kube" / "override-templates" / "01-config.yaml"
+)
+
+TEST_COMPONENT_OVERRIDE_TEMPLATE = """apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-component-configs
+data:
+  ENV: "{{ ENV }}"
+"""
+
+
+TEST_COMPONENT_RENDERED_OVERRIDE_PATH = (
+    TEST_ENV_PATH / "overrides" / TEST_COMPONENT_PATH / "kube" / "01-config.yaml"
+)
+
+TEST_COMPONENT_RENDERED_OVERRIDE = """apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-component-configs
+data:
+  ENV: "development"
+"""
+
 
 TEST_ENV_SECRETS_PATH = TEST_ENV_PATH / "secrets"
 TEST_ENV_SEALED_SECRETS_PATH = TEST_ENV_SECRETS_PATH / "01-test-secrets.yaml"

--- a/devops/tests/test_tasks.py
+++ b/devops/tests/test_tasks.py
@@ -13,18 +13,15 @@ from devops.tasks import (
     unseal_secrets,
     update_from_templates,
 )
+from devops.tests.conftest import TEST_ENV, TEST_ENV_PATH
 from devops.tests.test_utils import (
     TEST_COMPONENT_OVERRIDE_TEMPLATE,
     TEST_COMPONENT_OVERRIDE_TEMPLATE_PATH,
     TEST_COMPONENT_RENDERED_OVERRIDE,
     TEST_COMPONENT_RENDERED_OVERRIDE_PATH,
-    TEST_ENV,
-    TEST_ENV_PATH,
     TEST_ENV_SETTINGS,
     TEST_SETTINGS,
     TEST_SETTINGS_WITH_VARIABLES,
-    clean_test_component,
-    clean_test_settings,
 )
 
 TEST_ENV_SECRETS_PATH = TEST_ENV_PATH / "secrets"

--- a/devops/tests/test_utils.py
+++ b/devops/tests/test_utils.py
@@ -11,18 +11,11 @@ import yaml
 from devops.lib.utils import list_envs, load_env_settings, merge_docs, run
 from devops.tests.conftest import (
     ENVS_PATH,
-    TEST_COMPONENT_PATH,
     TEST_ENV,
     TEST_ENV_PATH,
+    TEST_ENV_SETTINGS,
+    TEST_SETTINGS,
 )
-
-TEST_ENV_SETTINGS = TEST_ENV_PATH / "settings.py"
-
-TEST_SETTINGS = """
-COMPONENTS = ["service/TEST_COMPONENT_LOL"]
-KUBE_CONTEXT = "TEST_CONTEXT_LOL"
-KUBE_NAMESPACE = "TEST_NAMESPACE_LOL"
-"""
 
 TEST_FULL_SETTINGS = (
     TEST_SETTINGS
@@ -247,34 +240,6 @@ spec:
                - /tmp/healthy
             initialDelaySeconds: 5
             periodSeconds: 5
-"""
-
-TEST_SETTINGS_WITH_VARIABLES = (
-    TEST_SETTINGS
-    + """
-TEMPLATE_VARIABLES = {"ENV": "development"}
-"""
-)
-
-TEST_COMPONENT_OVERRIDE_TEMPLATE_PATH = (
-    TEST_COMPONENT_PATH / "kube" / "override-templates" / "01-config.yaml"
-)
-TEST_COMPONENT_OVERRIDE_TEMPLATE = """apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: test-component-configs
-data:
-  ENV: "{{ ENV }}"
-"""
-TEST_COMPONENT_RENDERED_OVERRIDE_PATH = (
-    TEST_ENV_PATH / "overrides" / TEST_COMPONENT_PATH / "kube" / "01-config.yaml"
-)
-TEST_COMPONENT_RENDERED_OVERRIDE = """apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: test-component-configs
-data:
-  ENV: "development"
 """
 
 

--- a/devops/tests/test_utils.py
+++ b/devops/tests/test_utils.py
@@ -9,10 +9,13 @@ import pytest
 import yaml
 
 from devops.lib.utils import list_envs, load_env_settings, merge_docs, run
+from devops.tests.conftest import (
+    ENVS_PATH,
+    TEST_COMPONENT_PATH,
+    TEST_ENV,
+    TEST_ENV_PATH,
+)
 
-ENVS_PATH = Path("envs")
-TEST_ENV = "unit_test_env_6zxuj"
-TEST_ENV_PATH = ENVS_PATH / TEST_ENV
 TEST_ENV_SETTINGS = TEST_ENV_PATH / "settings.py"
 
 TEST_SETTINGS = """
@@ -253,7 +256,6 @@ TEMPLATE_VARIABLES = {"ENV": "development"}
 """
 )
 
-TEST_COMPONENT_PATH = Path("service/TEST_COMPONENT_LOL")
 TEST_COMPONENT_OVERRIDE_TEMPLATE_PATH = (
     TEST_COMPONENT_PATH / "kube" / "override-templates" / "01-config.yaml"
 )
@@ -280,30 +282,6 @@ def clean_caches():
     for path in Path(".").rglob("__pycache__"):
         rmtree(path)
     invalidate_caches()
-
-
-def delete_test_settings():
-    if TEST_ENV_PATH.exists():
-        rmtree(TEST_ENV_PATH)
-
-
-@pytest.fixture()
-def clean_test_settings():
-    delete_test_settings()
-    yield None
-    delete_test_settings()
-
-
-def delete_test_component():
-    if TEST_COMPONENT_PATH.exists():
-        rmtree(TEST_COMPONENT_PATH)
-
-
-@pytest.fixture()
-def clean_test_component():
-    delete_test_component()
-    yield None
-    delete_test_component()
 
 
 def test_load_env_settings(clean_test_settings):

--- a/devops/tests/test_utils.py
+++ b/devops/tests/test_utils.py
@@ -246,6 +246,35 @@ spec:
             periodSeconds: 5
 """
 
+TEST_SETTINGS_WITH_VARIABLES = (
+    TEST_SETTINGS
+    + """
+TEMPLATE_VARIABLES = {"ENV": "development"}
+"""
+)
+
+TEST_COMPONENT_PATH = Path("service/TEST_COMPONENT_LOL")
+TEST_COMPONENT_OVERRIDE_TEMPLATE_PATH = (
+    TEST_COMPONENT_PATH / "kube" / "override-templates" / "01-config.yaml"
+)
+TEST_COMPONENT_OVERRIDE_TEMPLATE = """apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-component-configs
+data:
+  ENV: "{{ ENV }}"
+"""
+TEST_COMPONENT_RENDERED_OVERRIDE_PATH = (
+    TEST_ENV_PATH / "overrides" / TEST_COMPONENT_PATH / "kube" / "01-config.yaml"
+)
+TEST_COMPONENT_RENDERED_OVERRIDE = """apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-component-configs
+data:
+  ENV: "development"
+"""
+
 
 def clean_caches():
     for path in Path(".").rglob("__pycache__"):
@@ -263,6 +292,18 @@ def clean_test_settings():
     delete_test_settings()
     yield None
     delete_test_settings()
+
+
+def delete_test_component():
+    if TEST_COMPONENT_PATH.exists():
+        rmtree(TEST_COMPONENT_PATH)
+
+
+@pytest.fixture()
+def clean_test_component():
+    delete_test_component()
+    yield None
+    delete_test_component()
 
 
 def test_load_env_settings(clean_test_settings):

--- a/tasks.py
+++ b/tasks.py
@@ -272,7 +272,7 @@ def update_from_templates(ctx):
     Update kube yaml merges from templates
     :param Context ctx:
     """
-    devops.tasks.update_from_templates(ctx)
+    devops.tasks.update_from_templates()
 
 
 @task()
@@ -283,7 +283,7 @@ def _update_from_templates_hook(ctx):
 
     :param Context ctx:
     """
-    rendered_files = devops.tasks.update_from_templates(ctx)
+    rendered_files = devops.tasks.update_from_templates()
 
     result = run(["git", "status", "--untracked-files=all", "-s"])
     untracked_files = result.stdout.decode(encoding="utf-8").split()


### PR DESCRIPTION
- If a component is removed from an env, make sure the rendered templates for it are also deleted.
- Add tests for rendering templates
- Make sure load_env_settings reloads settings each time from filesystem if they've been loaded earlier. The reuse of already imported versions caused issues for tests that were modifying the settings and caused tests to depend on each other.
- Add .DS_Store to .gitignore
- Remove unused ctx from update_from_templates task