### PR TITLE
Improvements to invoke commands for handling Sealed Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ poetry run invoke seal-secrets --env <env>
 This will base64 encode all the values and then seal the secrets using `envs/<env>/secrets.pem`.
 
 Note that also unchanged secrets will show up as changed in the SealedSecrets yaml file due to how kubeseal works.
+This can be mitigated using the `--only-changed` flag, which requires the `master.key` (or sufficient privileges to retrieve it from the cluster).
 
 
 ### License

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -3,7 +3,7 @@ import random
 import string
 from pathlib import Path
 from shutil import rmtree
-from typing import Iterable, List
+from typing import List
 
 import pytimeparse
 import yaml

--- a/devops/tests/test_tasks.py
+++ b/devops/tests/test_tasks.py
@@ -221,13 +221,13 @@ def test_seal_unseal_secrets(clean_test_settings):
     TEST_ENV_SECRETS_PATH.mkdir()
     TEST_ENV_UNSEALED_SECRETS_PATH.write_text(BASE64_DECODED_SECRETS, encoding="utf-8")
 
-    seal_secrets([TEST_ENV])
+    seal_secrets(TEST_ENV)
     TEST_ENV_UNSEALED_SECRETS_PATH.unlink()
     assert TEST_ENV_SEALED_SECRETS_PATH.exists()
     sealed_secrets = yaml.load(TEST_ENV_SEALED_SECRETS_PATH)
     assert sealed_secrets["kind"] == "SealedSecret"
 
-    unseal_secrets([TEST_ENV])
+    unseal_secrets(TEST_ENV)
 
     assert TEST_ENV_UNSEALED_SECRETS_PATH.exists()
 
@@ -237,12 +237,12 @@ def test_seal_unseal_secrets(clean_test_settings):
 
     # Check the sealed files are identical if only changed secrets are to be updated
     original_sealed_content = TEST_ENV_SEALED_SECRETS_PATH.read_text(encoding="utf-8")
-    seal_secrets([TEST_ENV], only_changed=True)
+    seal_secrets(TEST_ENV, only_changed=True)
     resealed_content = TEST_ENV_SEALED_SECRETS_PATH.read_text(encoding="utf-8")
     assert original_sealed_content == resealed_content
 
     # ... and not identical if all secrets should be updated
-    seal_secrets([TEST_ENV], only_changed=False)
+    seal_secrets(TEST_ENV, only_changed=False)
     resealed_content = TEST_ENV_SEALED_SECRETS_PATH.read_text(encoding="utf-8")
     assert original_sealed_content != resealed_content
 

--- a/devops/tests/test_tasks.py
+++ b/devops/tests/test_tasks.py
@@ -221,19 +221,33 @@ def test_seal_unseal_secrets(clean_test_settings):
     TEST_ENV_SECRETS_PATH.mkdir()
     TEST_ENV_UNSEALED_SECRETS_PATH.write_text(BASE64_DECODED_SECRETS, encoding="utf-8")
 
-    seal_secrets(TEST_ENV)
+    seal_secrets([TEST_ENV])
     TEST_ENV_UNSEALED_SECRETS_PATH.unlink()
     assert TEST_ENV_SEALED_SECRETS_PATH.exists()
     sealed_secrets = yaml.load(TEST_ENV_SEALED_SECRETS_PATH)
     assert sealed_secrets["kind"] == "SealedSecret"
 
-    unseal_secrets(TEST_ENV)
-    TEST_ENV_SEALED_SECRETS_PATH.unlink()
+    unseal_secrets([TEST_ENV])
+
     assert TEST_ENV_UNSEALED_SECRETS_PATH.exists()
 
     new_decoded_secrets = yaml.load(TEST_ENV_UNSEALED_SECRETS_PATH)
     assert new_decoded_secrets["kind"] == "Secret"
     assert new_decoded_secrets["data"] == original_decoded_secrets["data"]
+
+    # Check the sealed files are identical if only changed secrets are to be updated
+    original_sealed_content = TEST_ENV_SEALED_SECRETS_PATH.read_text(encoding="utf-8")
+    seal_secrets([TEST_ENV], only_changed=True)
+    resealed_content = TEST_ENV_SEALED_SECRETS_PATH.read_text(encoding="utf-8")
+    assert original_sealed_content == resealed_content
+
+    # ... and not identical if all secrets should be updated
+    seal_secrets([TEST_ENV], only_changed=False)
+    resealed_content = TEST_ENV_SEALED_SECRETS_PATH.read_text(encoding="utf-8")
+    assert original_sealed_content != resealed_content
+
+    TEST_ENV_SEALED_SECRETS_PATH.unlink()
+    TEST_ENV_UNSEALED_SECRETS_PATH.unlink()
 
 
 def test_update_from_templates(clean_test_settings, clean_test_component):

--- a/tasks.py
+++ b/tasks.py
@@ -384,28 +384,45 @@ def get_master_key(ctx, env):
     devops.tasks.get_master_key(env=env)
 
 
-@task()
-def unseal_secrets(ctx, env):
-    """Decrypts the secrets for the desired env and base64 decodes them to make
+@task(iterable=["env"])
+def unseal_secrets(ctx, env, all_envs=False):
+    """Decrypts the secrets for the desired env(s) and base64 decodes them to make
     them easy to edit.
 
     Examples:
-    poetry run invoke secrets.unseal-secrets --env staging
+    poetry run invoke unseal-secrets --env staging
+    poetry run invoke unseal-secrets --env staging --env production
+    poetry run invoke unseal-secrets --env staging,production
+    poetry run invoke unseal-secrets --all-envs
 
     :param invoke.Context ctx: The invoke context.
-    :param str env: The environment.
+    :param List[str] env: A list of the environments.
+    :param bool all_envs: Use all envs.
     """
-    devops.tasks.unseal_secrets(env=env)
+    if all_envs:
+        envs = list_envs()
+    else:
+        envs = {e.strip() for es in env for e in es.split(",")}
+    devops.tasks.unseal_secrets(envs=envs)
 
 
-@task()
-def seal_secrets(ctx, env):
-    """Base64 encodes and seals the secrets for the desired env.
+@task(iterable=["env"])
+def seal_secrets(ctx, env, all_envs=False, only_changed=False):
+    """Base64 encodes and seals the secrets for the desired env(s).
 
     Examples:
-    poetry run invoke secrets.seal-secrets --env staging
+    poetry run invoke seal-secrets --env staging
+    poetry run invoke seal-secrets --env staging --env production
+    poetry run invoke seal-secrets --env staging,production
+    poetry run invoke seal-secrets --all-envs
 
     :param invoke.Context ctx: The invoke context.
-    :param str env: The environment.
+    :param List[str] env: A list of the environments.
+    :param bool all_envs: Use all envs.
+    :param bool only_changed: Only reseal changed secrets.
     """
-    devops.tasks.seal_secrets(env=env)
+    if all_envs:
+        envs = list_envs()
+    else:
+        envs = {e.strip() for es in env for e in es.split(",")}
+    devops.tasks.seal_secrets(envs=envs, only_changed=only_changed)

--- a/tasks.py
+++ b/tasks.py
@@ -381,7 +381,7 @@ def get_master_key(ctx, env):
     :param invoke.Context ctx: The invoke context.
     :param str env: The environment (one from /envs/)
     """
-    devops.tasks.get_master_key(env=env)
+    devops.tasks.get_master_key(env=env, use_existing=False)
 
 
 @task(iterable=["env"])
@@ -403,7 +403,9 @@ def unseal_secrets(ctx, env, all_envs=False):
         envs = list_envs()
     else:
         envs = {e.strip() for es in env for e in es.split(",")}
-    devops.tasks.unseal_secrets(envs=envs)
+
+    for env in envs:
+        devops.tasks.unseal_secrets(env=env)
 
 
 @task(iterable=["env"])
@@ -426,4 +428,6 @@ def seal_secrets(ctx, env, all_envs=False, only_changed=False):
         envs = list_envs()
     else:
         envs = {e.strip() for es in env for e in es.split(",")}
-    devops.tasks.seal_secrets(envs=envs, only_changed=only_changed)
+
+    for env in envs:
+        devops.tasks.seal_secrets(env=env, only_changed=only_changed)

--- a/tasks.py
+++ b/tasks.py
@@ -412,6 +412,7 @@ def seal_secrets(ctx, env, all_envs=False, only_changed=False):
 
     Examples:
     poetry run invoke seal-secrets --env staging
+    poetry run invoke seal-secrets --env staging --only-changed
     poetry run invoke seal-secrets --env staging --env production
     poetry run invoke seal-secrets --env staging,production
     poetry run invoke seal-secrets --all-envs


### PR DESCRIPTION
- Allow easy sealing/unsealing of multiple envs or all envs at once.
- Added the `--only-changed` flag to `unseal-secrets` to avoid resealing all unchanged secrets.