### PR TITLE
Ensure consistent formatting of Sealed Secrets

### DIFF
--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -395,6 +395,9 @@ def seal_secrets(env: str, only_changed=False) -> None:
             sealed_content = _revert_unchanged_secrets(
                 content, sealed_content, original_content, sealed_original_content
             )
+        else:
+            # Load and dump yaml to ensure consistent formatting with above
+            sealed_content = yaml.safe_dump(yaml.safe_load(sealed_content))
 
         output_file.write_text(sealed_content, encoding="utf-8")
 


### PR DESCRIPTION
If you were sealing secrets with annotations like `sealedsecrets.bitnami.com/namespace-wide: "true"` the formatting of quotes was different if you used `--only-changed` flag (dumped by PyYAML with single quotes) or not (output straight as is from `kubeseal` with double quotes). This fixes it by always running it through PyYAML to ensure consistent formatting.