### PR TITLE
Fix handling of newlines in secrets

### DIFF
--- a/devops/lib/utils.py
+++ b/devops/lib/utils.py
@@ -1,3 +1,4 @@
+import base64
 import importlib
 import subprocess  # nosec
 import sys
@@ -291,3 +292,38 @@ def get_merged_kube_file(path: Path, merge_temp: Path) -> Path:
         yaml.dump_all(merged_docs, stream=f, Dumper=yaml.Dumper)
 
     return output_file
+
+
+def normalize_line_endings(data: str) -> str:
+    """
+    Normalize line endings of given input to \n, same universal format as used in
+    PEP 278 -- Universal Newline Support.
+
+    :param data: A string with Unix, Windows or Mac newlines.
+    :return: A string with universal (Unix) newlines.
+    """
+    unix_nl = "\n"
+    windows_nl = "\r\n"
+    mac_nl = "\r"
+
+    return data.replace(windows_nl, unix_nl).replace(mac_nl, unix_nl)
+
+
+def base64decode(data: str) -> str:
+    """
+    Base64 decode a string.
+
+    :param data: The base64 encoded string.
+    :return: The decoded string.
+    """
+    return base64.b64decode(data.encode()).decode()
+
+
+def base64encode(data: str) -> str:
+    """
+    Base64 encode a string.
+
+    :param data: The decoded string.
+    :return: The base64 encoded string.
+    """
+    return base64.b64encode(data.encode()).decode()

--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -457,6 +457,7 @@ def base64_decode_secrets(content: str) -> str:
     for key, value in data.items():
         if value is not None:
             value = base64decode(value)
+            value = normalize_line_endings(value)
             if "\n" in value:
                 # If there's a line break in the value we want to dump it using
                 # the literal syntax. This will use the pipe symbol (|) to
@@ -483,6 +484,7 @@ def base64_encode_secrets(content: str) -> str:
     data = secrets["data"]
     for key, value in data.items():
         if value is not None:
+            value = normalize_line_endings(value)
             value = base64encode(value)
             data[key] = PlainScalarString(value)
 

--- a/devops/tests/test_utils.py
+++ b/devops/tests/test_utils.py
@@ -8,7 +8,15 @@ from shutil import rmtree
 import pytest
 import yaml
 
-from devops.lib.utils import list_envs, load_env_settings, merge_docs, run
+from devops.lib.utils import (
+    base64decode,
+    base64encode,
+    list_envs,
+    load_env_settings,
+    merge_docs,
+    normalize_line_endings,
+    run,
+)
 from devops.tests.conftest import (
     ENVS_PATH,
     TEST_ENV,
@@ -328,3 +336,20 @@ def test_list_envs(folder):
         assert "minikube" in envs
     finally:
         path.rmdir()
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("foo\r\nbar", "foo\nbar"),
+        ("\rfoo\nbar\r\n", "\nfoo\nbar\n"),
+        ("\r\rfoo\r\nbar\n\r", "\n\nfoo\nbar\n\n"),
+    ],
+)
+def test_normalize_line_endings(text, expected):
+    assert normalize_line_endings(text) == expected
+
+
+@pytest.mark.parametrize("orig", ["foo", "åäö"])
+def test_base64(orig):
+    assert base64decode(base64encode(orig)) == orig


### PR DESCRIPTION
If unsealing secrets and then sealing again with `invoke seal-secrets --only-changed` multiline secrets (such as PEM keys) were detected as changed if they had been originally sealed on Windows and were unsealed and sealed again on Unix based systems.