### PR TITLE
Bugfix: Fix issue with sealed secrets with empty (null) value

### DIFF
--- a/devops/tasks.py
+++ b/devops/tasks.py
@@ -431,12 +431,18 @@ def _revert_unchanged_secrets(
     orig_content = yaml.safe_load(orig_content)
     sealed_orig_content = yaml.safe_load(sealed_orig_content)
 
-    for key, new_b64 in new_content["data"].items():
+    for key, new in new_content["data"].items():
         if key in orig_content["data"]:
-            orig_b64 = orig_content["data"][key]
-            new = base64decode(new_b64)
-            orig = base64decode(orig_b64)
-            if normalize_line_endings(orig) == normalize_line_endings(new):
+            orig = orig_content["data"][key]
+            if new is not None:
+                new = base64decode(new)
+                new = normalize_line_endings(new)
+
+            if orig is not None:
+                orig = base64decode(orig)
+                orig = normalize_line_endings(orig)
+
+            if new == orig:
                 orig_sealed_value = sealed_orig_content["spec"]["encryptedData"][key]
                 new_sealed_content["spec"]["encryptedData"][key] = orig_sealed_value
 

--- a/devops/tests/test_tasks.py
+++ b/devops/tests/test_tasks.py
@@ -80,6 +80,7 @@ data:
     Tabw4C6DPpfMA3XlhJkhAkEAoIcAcIwMxj2i46WdlSL8zt/5EAgeF0jdCLJPU6J5
     xrbc46CIEyiNKpyhIdDOcZqsUevytVTyOxSnnsOYBdW5LA==
     -----END RSA PRIVATE KEY-----
+  some_missing_value:
 kind: Secret
 metadata:
   name: test-secrets
@@ -107,6 +108,7 @@ data:
     Tabw4C6DPpfMA3XlhJkhAkEAoIcAcIwMxj2i46WdlSL8zt/5EAgeF0jdCLJPU6J5
     xrbc46CIEyiNKpyhIdDOcZqsUevytVTyOxSnnsOYBdW5LA==
     -----END RSA PRIVATE KEY-----
+  some_missing_value:
 kind: Secret
 metadata:
   annotations:


### PR DESCRIPTION
If a Sealed Secret has an empty (null) value, unsealing works all right, but sealing with `--only-changed` fails, as string operations fail on None.